### PR TITLE
Added support for authenticated requests to Depot

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -6,6 +6,7 @@ pkg_upstream_url="https://github.com/habitat-sh/habitat-updater"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_bin_dirs=(bin)
+pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/git core/dep)
 pkg_svc_run="${pkg_name}"
 


### PR DESCRIPTION
This PR adds support for private Habitat packages to be updated. Previously only public packages could be updated with the habitat-updater.

If the `HAB_AUTH_TOKEN` is present and has a value, the appropriate HTTP header will be added to the HTTP request. This is in the format:

`Authorization: Bearer <HAB_AUTH_TOKEN>`

The token can be specified from a secret in the deployment manifest of the updater, e.g.

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: habitat-updater
spec:
  replicas: 1
  template:
    metadata:
      labels:
        name: habitat-updater
    spec:
      containers:
      - name: habitat-updater
        image: russellseymour/habitat-updater
        env:
        - name: HAB_AUTH_TOKEN
          valueFrom:
            secretKeyRef:
              name: tokens
              key: HAB_AUTH_TOKEN
      serviceAccountName: habitat-updater
```

Additionally I have added some more information to the output so that it is possible to see the local cluster version and the version that is in the Depot. For example:

```
Depot version on channel 'stable': 20181030162731
Cluster version: 20181030162731
Latest version of turtleblog installed
```

I think I have found a bug in export of Habitat, in that it is not possible to change the channel that is set on the Docker image. I have raised this as [Issue #5802](https://github.com/habitat-sh/habitat/issues/5802). This means that only the stable channel is monitored, but this should be configurable on the docker export.

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>